### PR TITLE
remove @mui/style

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
     "@fontsource/roboto": "^5.0.13",
     "@mui/icons-material": "^5.16.0",
     "@mui/material": "^5.16.0",
-    "@mui/styled-engine-sc": "^6.0.0-alpha.18",
-    "@mui/styles": "^5.16.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.24.1",

--- a/src/pages/offers.jsx
+++ b/src/pages/offers.jsx
@@ -23,35 +23,8 @@ const Offers = () => {
             mileage: '10.000 km',
             registrationDate: '01/01/2021',
             views: 0
-        }, {
-            id: 2,
-            photo: 'https://via.placeholder.com/150',
-            photos: ['https://via.placeholder.com/150', 'https://via.placeholder.com/150'],
-            price: 'R$ 50.000',
-            brand: 'Marca A',
-            model: 'Modelo A',
-            year: 2020,
-            color: 'Preto',
-            plate: 'ABC-1234',
-            city: 'Cidade A',
-            mileage: '10.000 km',
-            registrationDate: '01/01/2021',
-            views: 0
-        }, {
-            id: 3,
-            photo: 'https://via.placeholder.com/150',
-            photos: ['https://via.placeholder.com/150', 'https://via.placeholder.com/150'],
-            price: 'R$ 50.000',
-            brand: 'Marca A',
-            model: 'Modelo A',
-            year: 2020,
-            color: 'Preto',
-            plate: 'ABC-1234',
-            city: 'Cidade A',
-            mileage: '10.000 km',
-            registrationDate: '01/01/2021',
-            views: 0
         },
+        // Adicione mais carros conforme necessário
     ]);
 
     const handleCardClick = (car) => {
@@ -64,10 +37,17 @@ const Offers = () => {
     }
 
     return (
-        <div className="container mx-auto">
-            <ButtonGroup variant="contained" aria-label="outlined primary button group">
+        <div className="container mx-auto p-4">
+            <ButtonGroup variant="contained" aria-label="outlined primary button group" className='gap-[6px]'>
                 <Button onClick={() => setView('grid')}>Grade</Button>
                 <Button onClick={() => setView('list')}>Lista</Button>
+                <Button
+                    variant="contained"
+                    color="secondary"
+                    href='home'
+                >
+                    Voltar para a Home
+                </Button>
             </ButtonGroup>
             {view === 'grid' ? (
                 <CarGrid cars={cars} onCardClick={handleCardClick} />


### PR DESCRIPTION
**Descrição:**

Remoção do uso de `@mui/styles` devido a problemas de implantação no GitHub Pages durante a instalação das dependências do projeto.

**Motivação:**

A biblioteca `@mui/styles` está causando falhas na instalação das dependências, resultando em erros de implantação no GitHub Pages. Esta mudança visa resolver esses problemas ao remover a dependência problemática.

**Mudanças Realizadas:**

- Removido o uso de `@mui/styles` do projeto.
- Atualizações necessárias nos estilos e componentes afetados para garantir compatibilidade com outras soluções de estilização.

**Testes Realizados:**

- Testado localmente para garantir que a remoção do `@mui/styles` não introduziu novos bugs ou problemas de renderização.
